### PR TITLE
Replace Eos with Fiveam

### DIFF
--- a/cl-moneris-test.asd
+++ b/cl-moneris-test.asd
@@ -9,4 +9,4 @@
             :serial t
             :components ((:file "package")
                          (:file "moneris-test"))))
-  :depends-on (:cl-moneris :eos))
+  :depends-on (:cl-moneris :fiveam))

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -1,2 +1,2 @@
 (cl:defpackage #:cl-moneris-test
-  (:use :cl :cl-moneris :eos))
+  (:use :cl :cl-moneris :fiveam))


### PR DESCRIPTION
Eos has been deprecated in favor of Fiveam